### PR TITLE
feat: add custom initdata support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@fluidkey/stealth-account-kit": "^0.0.30",
+    "@fluidkey/stealth-account-kit": "1.1.0",
     "@mantine/core": "7.6.1",
     "@mantine/hooks": "7.6.1",
     "@rainbow-me/rainbowkit": "^2.0.1",

--- a/src/components/Journey.model.ts
+++ b/src/components/Journey.model.ts
@@ -1,4 +1,4 @@
-import { predictStealthSafeAddressWithBytecode, predictStealthSafeAddressWithClient } from "@fluidkey/stealth-account-kit";
+import { predictStealthSafeAddressWithBytecode } from "@fluidkey/stealth-account-kit";
 import { GetBalanceReturnType, getBalance } from "@wagmi/core";
 import { isEmpty } from "lodash";
 import { formatUnits } from "viem";

--- a/src/components/Journey.model.ts
+++ b/src/components/Journey.model.ts
@@ -1,4 +1,4 @@
-import { predictStealthSafeAddressWithBytecode } from "@fluidkey/stealth-account-kit";
+import { predictStealthSafeAddressWithBytecode, predictStealthSafeAddressWithClient } from "@fluidkey/stealth-account-kit";
 import { GetBalanceReturnType, getBalance } from "@wagmi/core";
 import { isEmpty } from "lodash";
 import { formatUnits } from "viem";
@@ -122,6 +122,10 @@ export const createCSVEntry = async (
       stealthAddresses: params.stealthAddresses,
       useDefaultAddress: params.settings.useDefaultAddress,
       safeVersion: params.settings.safeVersion,
+      initializerExtraFields: {
+        to: params.settings.initializerTo,
+        data: params.settings.initializerData,
+      },
     });
 
     const balances = await getBalances(

--- a/src/components/RecoverAddressesJourneyStep.tsx
+++ b/src/components/RecoverAddressesJourneyStep.tsx
@@ -362,6 +362,22 @@ export const RecoverAddressesJourneyStep = (props: ComponentProps) => {
                 />
               </Box>
             </Grid.Col>
+            <Grid.Col span={12}>
+              <TextInput
+                label="Initializer to address"
+                placeholder="0x..."
+                onChange={(v) =>
+                  handleSettingsChange("initializerTo", v.target.value)
+                }
+              />
+              <TextInput
+                label="Initializer data"
+                placeholder="0x..."
+                onChange={(v) =>
+                  handleSettingsChange("initializerData", v.target.value)
+                }
+              />
+            </Grid.Col>
           </Grid>
         </Collapse>
       </StepContent>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,11 +16,13 @@ export type FluidKeyStealthSafeAddressGenerationParams = {
   useDefaultAddress: boolean;
   exportPrivateKeys?: boolean;
   customTransport?: string | undefined;
+  initializerTo?: Address | undefined;
+  initializerData?: Address | undefined;
 };
 
 export type CreateCSVEntryParams = {
   nonce: number;
-  stealthAddresses: string[];
+  stealthAddresses: Address[];
   settings: FluidKeyStealthSafeAddressGenerationParams;
   activeChainId: SupportedChainId;
   meta: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -562,10 +562,10 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.1.tgz#16308cea045f0fc777b6ff20a9f25474dd8293d2"
   integrity sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==
 
-"@fluidkey/stealth-account-kit@^0.0.30":
-  version "0.0.30"
-  resolved "https://registry.yarnpkg.com/@fluidkey/stealth-account-kit/-/stealth-account-kit-0.0.30.tgz#ce06c23ee73d4a95ed892a314113802495ce714d"
-  integrity sha512-Kvno62kqItfasgbuONjin1rzOQ3JEe95x3zIBCrFTJhoXTQ0gKo8+c8cpARyl9tSifoLuvB83gdjLlg8VHa5Yw==
+"@fluidkey/stealth-account-kit@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@fluidkey/stealth-account-kit/-/stealth-account-kit-1.1.0.tgz#7ee402c72883ffe52f955c989ea1ae9a53e93456"
+  integrity sha512-8iL3gI6rTH5x7ZA4tbRKwMBhhfftyV/5VvJBG1dYQWD/x0zHUWUfUcPIlD479dgWhR8X9QegcnG7h4ouhl5D3w==
   dependencies:
     "@noble/secp256k1" "1.7.1"
     "@safe-global/safe-deployments" "1.29.0"


### PR DESCRIPTION
Fluidkey now supports stealth addresses with modules (see our recent [auto-earn feature](https://docs.fluidkey.com/readme/earn)). In order to recover addresses with modules in the initdata I've added two parameters in the advanced settings. We are also about to publish the initdata in our docs so users can easily copy and paste it from there.