### PR TITLE
Remove balance check without transport set

### DIFF
--- a/src/components/Journey.model.ts
+++ b/src/components/Journey.model.ts
@@ -128,15 +128,21 @@ export const createCSVEntry = async (
       },
     });
 
-    const balances = await getBalances(
-      stealthSafeAddress,
-      params.settings.chainId > 0
-        ? (params.settings.chainId as SupportedChainId)
-        : params.activeChainId,
-      params.settings.customTransport
-    );
-    const settledBalances = filterSettledBalances(balances);
-    const filledBalances = fillRejectedBalances(settledBalances);
+    let filledBalances = ["-", "-", "-", "-"];
+    let status = "Success";
+
+    if (params.settings.customTransport) {
+      const balances = await getBalances(
+        stealthSafeAddress,
+        params.settings.chainId > 0
+          ? (params.settings.chainId as SupportedChainId)
+          : params.activeChainId,
+        params.settings.customTransport
+      );
+      const settledBalances = filterSettledBalances(balances);
+      filledBalances = fillRejectedBalances(settledBalances);
+      status = settledBalances.length < balances.length ? "Partial Success" : "Success";
+    }
 
     callback();
 
@@ -148,7 +154,7 @@ export const createCSVEntry = async (
         ? getPrivateKeyForSigner({ ...params.meta })
         : "-",
       ...filledBalances,
-      settledBalances.length < balances.length ? "Partial Success" : "Success",
+      status,
     ];
   } catch (e) {
     return [

--- a/src/components/RecoverAddressesJourneyStep.tsx
+++ b/src/components/RecoverAddressesJourneyStep.tsx
@@ -108,20 +108,21 @@ export const RecoverAddressesJourneyStep = (props: ComponentProps) => {
           },
         };
 
+        const updateProgress = () => {
+          setProgress(
+            normalizeForRange(
+              counter++,
+              0,
+              settings.endNonce - settings.startNonce,
+              0,
+              100
+            )
+          );
+        };
         promises.push(
-          scheduleRequest<string[]>(
-            createCSVEntry.bind(null, params, () => {
-              setProgress(
-                normalizeForRange(
-                  counter++,
-                  0,
-                  settings.endNonce - settings.startNonce,
-                  0,
-                  100
-                )
-              );
-            })
-          )
+          settings.customTransport
+            ? scheduleRequest<string[]>(createCSVEntry.bind(null, params, updateProgress))
+            : createCSVEntry(params, updateProgress)
         );
       }
 
@@ -290,7 +291,7 @@ export const RecoverAddressesJourneyStep = (props: ComponentProps) => {
                   }
                 />
                 <TextInput
-                  label="Custom RPC URL"
+                  label="Check balances onchain"
                   placeholder="https://rpc.example.com"
                   onChange={(v) =>
                     handleSettingsChange("customTransport", v.target.value)

--- a/src/components/StealthAddressStickyTable.tsx
+++ b/src/components/StealthAddressStickyTable.tsx
@@ -59,10 +59,14 @@ export const StealthAddressStickyTable = (props: ComponentProps) => {
           <CopyWithCheckButton value={item.stealthSignerKey} />
         </div>
       </Table.Td>
-      <Table.Td>{item.balances.ETH}</Table.Td>
-      <Table.Td>{item.balances.USDT}</Table.Td>
-      <Table.Td>{item.balances.USDC}</Table.Td>
-      <Table.Td>{item.balances.DAI}</Table.Td>
+      {Object.values(item.balances).some((balance) => balance !== "-") && (
+        <>
+          <Table.Td>{item.balances.ETH}</Table.Td>
+          <Table.Td>{item.balances.USDT}</Table.Td>
+          <Table.Td>{item.balances.USDC}</Table.Td>
+          <Table.Td>{item.balances.DAI}</Table.Td>
+        </>
+      )}
       <Table.Td>{item.status}</Table.Td>
     </Table.Tr>
   ));
@@ -85,10 +89,16 @@ export const StealthAddressStickyTable = (props: ComponentProps) => {
             <Table.Th>Safe Address</Table.Th>
             <Table.Th>Signer Address</Table.Th>
             <Table.Th>Signer Key</Table.Th>
-            <Table.Th>ETH</Table.Th>
-            <Table.Th>USDC</Table.Th>
-            <Table.Th>USDT</Table.Th>
-            <Table.Th>DAI</Table.Th>
+            {Object.values(props.items[0].balances).some(
+              (balance) => balance !== "-"
+            ) && (
+              <>
+                <Table.Th>ETH</Table.Th>
+                <Table.Th>USDC</Table.Th>
+                <Table.Th>USDT</Table.Th>
+                <Table.Th>DAI</Table.Th>
+              </>
+            )}
             <Table.Th>Status</Table.Th>
           </Table.Tr>
         </Table.Thead>


### PR DESCRIPTION
The process to generate 100s of stealth addresses is currently lengthy because of the onchain balance check. This adjustment enables the balance check only when a RPC is set in the advanced params, as in most cases users just want to recover the keys of their addresses to access their funds (e.g. when sending to a chain Fluidkey doesn't support). This enables the recovery of 1000s of addresses in seconds.